### PR TITLE
[@StudioAction] Add the target attribute #59

### DIFF
--- a/ui-data/src/main/java/io/jmix/uidata/action/filter/FilterMakeDefaultAction.java
+++ b/ui-data/src/main/java/io/jmix/uidata/action/filter/FilterMakeDefaultAction.java
@@ -28,7 +28,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Objects;
 
-@StudioAction(category = "Filter Actions", description = "Makes the filter configuration default for this screen")
+@StudioAction(
+        target = "io.jmix.ui.component.Filter",
+        description = "Makes the filter configuration default for this screen")
 @ActionType(FilterMakeDefaultAction.ID)
 public class FilterMakeDefaultAction extends FilterAction {
 

--- a/ui-data/src/main/java/io/jmix/uidata/action/filter/FilterRemoveAction.java
+++ b/ui-data/src/main/java/io/jmix/uidata/action/filter/FilterRemoveAction.java
@@ -26,7 +26,7 @@ import io.jmix.ui.icon.JmixIcon;
 import io.jmix.ui.meta.StudioAction;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@StudioAction(category = "Filter Actions", description = "Removes current run-time filter configuration")
+@StudioAction(target = "io.jmix.ui.component.Filter", description = "Removes current run-time filter configuration")
 @ActionType(FilterRemoveAction.ID)
 public class FilterRemoveAction extends FilterAction {
 

--- a/ui-data/src/main/java/io/jmix/uidata/action/filter/FilterSaveAction.java
+++ b/ui-data/src/main/java/io/jmix/uidata/action/filter/FilterSaveAction.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 
-@StudioAction(category = "Filter Actions", description = "Saves changes to current filter configuration")
+@StudioAction(target = "io.jmix.ui.component.Filter", description = "Saves changes to current filter configuration")
 @ActionType(FilterSaveAction.ID)
 public class FilterSaveAction extends FilterSaveAsAction {
 

--- a/ui-data/src/main/java/io/jmix/uidata/action/filter/FilterSaveAsAction.java
+++ b/ui-data/src/main/java/io/jmix/uidata/action/filter/FilterSaveAsAction.java
@@ -54,7 +54,8 @@ import java.util.function.Consumer;
 
 import static io.jmix.ui.component.filter.FilterUtils.generateConfigurationId;
 
-@StudioAction(category = "Filter Actions",
+@StudioAction(
+        target = "io.jmix.ui.component.Filter",
         description = "Saves current filter configuration under a new id and name")
 @ActionType(FilterSaveAsAction.ID)
 public class FilterSaveAsAction extends FilterAction {

--- a/ui-data/src/main/java/io/jmix/uidata/action/filter/FilterSaveWithValuesAction.java
+++ b/ui-data/src/main/java/io/jmix/uidata/action/filter/FilterSaveWithValuesAction.java
@@ -30,8 +30,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.annotation.Nullable;
 
-@StudioAction(category = "Filter Actions", description = "Saves changes to current filter configuration using the " +
-        "values in filter components as default values")
+@StudioAction(
+        target = "io.jmix.ui.component.Filter",
+        description = "Saves changes to current filter configuration using the values in filter components as default values")
 @ActionType(FilterSaveWithValuesAction.ID)
 public class FilterSaveWithValuesAction extends FilterSaveAction {
 

--- a/ui-export/src/main/java/io/jmix/uiexport/action/ExcelExportAction.java
+++ b/ui-export/src/main/java/io/jmix/uiexport/action/ExcelExportAction.java
@@ -13,7 +13,7 @@ import org.springframework.context.ApplicationContext;
  * <p>
  * Should be defined for a list component ({@code Table}, {@code DataGrid}, etc.) in a screen XML descriptor.
  */
-@StudioAction(category = "List Actions", description = "Export selected entities to Excel")
+@StudioAction(target = "io.jmix.ui.component.ListComponent", description = "Export selected entities to Excel")
 @ActionType(ExcelExportAction.ID)
 public class ExcelExportAction extends ExportAction {
 

--- a/ui-export/src/main/java/io/jmix/uiexport/action/ExportAction.java
+++ b/ui-export/src/main/java/io/jmix/uiexport/action/ExportAction.java
@@ -42,7 +42,10 @@ import javax.annotation.Nullable;
  * Should be defined for a list component ({@code Table}, {@code DataGrid}, etc.) in a screen XML descriptor.
  */
 @SuppressWarnings("rawtypes")
-@StudioAction(category = "List Actions", description = "Export selected entities")
+@StudioAction(
+        target = "io.jmix.ui.component.ListComponent",
+        description = "Export selected entities",
+        availableInScreenWizard = true)
 @ActionType(ExportAction.ID)
 public class ExportAction extends ListAction implements ApplicationContextAware {
 

--- a/ui-export/src/main/java/io/jmix/uiexport/action/JsonExportAction.java
+++ b/ui-export/src/main/java/io/jmix/uiexport/action/JsonExportAction.java
@@ -13,7 +13,7 @@ import org.springframework.context.ApplicationContext;
  * <p>
  * Should be defined for a list component ({@code Table}, {@code DataGrid}, etc.) in a screen XML descriptor.
  */
-@StudioAction(category = "List Actions", description = "Export selected entities to JSON")
+@StudioAction(target = "io.jmix.ui.component.ListComponent", description = "Export selected entities to JSON")
 @ActionType(JsonExportAction.ID)
 public class JsonExportAction extends ExportAction {
 

--- a/ui/src/main/java/io/jmix/ui/action/entitypicker/EntityClearAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/entitypicker/EntityClearAction.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
  * <p>
  * Should be defined for {@link EntityPicker} or its subclass in a screen XML descriptor.
  */
-@StudioAction(category = "EntityPicker Actions", description = "Clears the entity picker value")
+@StudioAction(target = "io.jmix.ui.component.EntityPicker", description = "Clears the entity picker value")
 @ActionType(EntityClearAction.ID)
 public class EntityClearAction extends ValueClearAction implements EntityPicker.EntityPickerAction {
 

--- a/ui/src/main/java/io/jmix/ui/action/entitypicker/EntityLookupAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/entitypicker/EntityLookupAction.java
@@ -43,7 +43,9 @@ import javax.annotation.Nullable;
  *
  * @param <E> type of entity
  */
-@StudioAction(category = "EntityPicker Actions", description = "Sets an entity to the entity picker using the entity lookup screen")
+@StudioAction(
+        target = "io.jmix.ui.component.EntityPicker",
+        description = "Sets an entity to the entity picker using the entity lookup screen")
 @ActionType(EntityLookupAction.ID)
 public class EntityLookupAction<E> extends AbstractLookupAction<E>
         implements EntityPicker.EntityPickerAction, Action.ScreenOpeningAction, InitializingBean,

--- a/ui/src/main/java/io/jmix/ui/action/entitypicker/EntityOpenAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/entitypicker/EntityOpenAction.java
@@ -55,7 +55,7 @@ import static io.jmix.ui.screen.FrameOwner.WINDOW_COMMIT_AND_CLOSE_ACTION;
  * The action instance can be parameterized using the nested {@code properties} XML element or programmatically in the
  * screen controller.
  */
-@StudioAction(category = "EntityPicker Actions", description = "Opens an entity using the entity edit screen")
+@StudioAction(target = "io.jmix.ui.component.EntityPicker", description = "Opens an entity using the entity edit screen")
 @ActionType(EntityOpenAction.ID)
 public class EntityOpenAction<E> extends BaseAction
         implements EntityPicker.EntityPickerAction, Action.ScreenOpeningAction, InitializingBean,

--- a/ui/src/main/java/io/jmix/ui/action/entitypicker/EntityOpenCompositionAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/entitypicker/EntityOpenCompositionAction.java
@@ -27,7 +27,9 @@ import io.jmix.ui.meta.StudioAction;
  * The action instance can be parameterized using the nested {@code properties} XML element or programmatically in the
  * screen controller.
  */
-@StudioAction(category = "EntityPicker Actions", description = "Opens a one-to-one composition entity using the entity edit screen")
+@StudioAction(
+        target = "io.jmix.ui.component.EntityPicker",
+        description = "Opens a one-to-one composition entity using the entity edit screen")
 @ActionType(EntityOpenCompositionAction.ID)
 public class EntityOpenCompositionAction extends EntityOpenAction {
 

--- a/ui/src/main/java/io/jmix/ui/action/filter/FilterAddConditionAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/filter/FilterAddConditionAction.java
@@ -43,7 +43,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 
-@StudioAction(category = "Filter Actions", description = "Adds condition to current filter configuration")
+@StudioAction(target = "io.jmix.ui.component.Filter", description = "Adds condition to current filter configuration")
 @ActionType(FilterAddConditionAction.ID)
 public class FilterAddConditionAction extends FilterAction {
 

--- a/ui/src/main/java/io/jmix/ui/action/filter/FilterClearValuesAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/filter/FilterClearValuesAction.java
@@ -24,7 +24,7 @@ import io.jmix.ui.icon.JmixIcon;
 import io.jmix.ui.meta.StudioAction;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@StudioAction(category = "Filter Actions", description = "Clears the filter condition values")
+@StudioAction(target = "io.jmix.ui.component.Filter", description = "Clears the filter condition values")
 @ActionType(FilterClearValuesAction.ID)
 public class FilterClearValuesAction extends FilterAction {
 

--- a/ui/src/main/java/io/jmix/ui/action/filter/FilterCopyAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/filter/FilterCopyAction.java
@@ -31,7 +31,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Map;
 
-@StudioAction(category = "Filter Actions",
+@StudioAction(
+        target = "io.jmix.ui.component.Filter",
         description = "Copies all conditions from design-time configuration to run-time configuration")
 @ActionType(FilterCopyAction.ID)
 public class FilterCopyAction extends FilterAction {

--- a/ui/src/main/java/io/jmix/ui/action/filter/FilterEditAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/filter/FilterEditAction.java
@@ -47,7 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-@StudioAction(category = "Filter Actions", description = "Edits current run-time filter configuration")
+@StudioAction(target = "io.jmix.ui.component.Filter", description = "Edits current run-time filter configuration")
 @ActionType(FilterEditAction.ID)
 public class FilterEditAction extends FilterAction {
 

--- a/ui/src/main/java/io/jmix/ui/action/list/AddAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/list/AddAction.java
@@ -54,7 +54,10 @@ import java.util.function.Supplier;
  *
  * @param <E> type of entity
  */
-@StudioAction(category = "List Actions", description = "Adds entities to the list using a lookup screen")
+@StudioAction(
+        target = "io.jmix.ui.component.ListComponent",
+        description = "Adds entities to the list using a lookup screen",
+        availableInScreenWizard = true)
 @ActionType(AddAction.ID)
 public class AddAction<E> extends ListAction
         implements Action.AdjustWhenScreenReadOnly, Action.ScreenOpeningAction, Action.ExecutableAction {

--- a/ui/src/main/java/io/jmix/ui/action/list/BulkEditAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/list/BulkEditAction.java
@@ -54,7 +54,9 @@ import static io.jmix.ui.component.ComponentsHelper.getScreenContext;
  * The action instance can be parameterized using the nested {@code properties} XML element or programmatically in the
  * screen controller.
  */
-@StudioAction(category = "List Actions", description = "Opens an editor for changing attribute values for several entity instances at once")
+@StudioAction(
+        target = "io.jmix.ui.component.ListComponent",
+        description = "Opens an editor for changing attribute values for several entity instances at once")
 @ActionType(BulkEditAction.ID)
 public class BulkEditAction extends SecuredListAction implements Action.ExecutableAction {
 

--- a/ui/src/main/java/io/jmix/ui/action/list/CreateAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/list/CreateAction.java
@@ -53,7 +53,10 @@ import static io.jmix.ui.screen.FrameOwner.WINDOW_COMMIT_AND_CLOSE_ACTION;
  *
  * @param <E> type of entity
  */
-@StudioAction(category = "List Actions", description = "Creates an entity instance using its editor screen")
+@StudioAction(
+        target = "io.jmix.ui.component.ListComponent",
+        description = "Creates an entity instance using its editor screen",
+        availableInScreenWizard = true)
 @ActionType(CreateAction.ID)
 public class CreateAction<E> extends ListAction
         implements Action.AdjustWhenScreenReadOnly, Action.ScreenOpeningAction, Action.ExecutableAction {

--- a/ui/src/main/java/io/jmix/ui/action/list/EditAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/list/EditAction.java
@@ -51,7 +51,10 @@ import static io.jmix.ui.screen.FrameOwner.WINDOW_COMMIT_AND_CLOSE_ACTION;
  *
  * @param <E> type of entity
  */
-@StudioAction(category = "List Actions", description = "Edits an entity instance using its editor screen")
+@StudioAction(
+        target = "io.jmix.ui.component.ListComponent",
+        description = "Edits an entity instance using its editor screen",
+        availableInScreenWizard = true)
 @ActionType(EditAction.ID)
 public class EditAction<E> extends SecuredListAction
         implements Action.AdjustWhenScreenReadOnly, Action.ScreenOpeningAction, Action.ExecutableAction {

--- a/ui/src/main/java/io/jmix/ui/action/list/ExcludeAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/list/ExcludeAction.java
@@ -46,7 +46,10 @@ import java.util.function.Consumer;
  * The action instance can be parameterized using the nested {@code properties} XML element or programmatically in the
  * screen controller.
  */
-@StudioAction(category = "List Actions", description = "Excludes entities from the list. The excluded entities are not deleted.")
+@StudioAction(
+        target = "io.jmix.ui.component.ListComponent",
+        description = "Excludes entities from the list. The excluded entities are not deleted.",
+        availableInScreenWizard = true)
 @ActionType(ExcludeAction.ID)
 public class ExcludeAction<E> extends SecuredListAction implements Action.AdjustWhenScreenReadOnly,
         Action.ExecutableAction {

--- a/ui/src/main/java/io/jmix/ui/action/list/RefreshAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/list/RefreshAction.java
@@ -40,7 +40,10 @@ import org.springframework.beans.factory.annotation.Autowired;
  * <p>
  * Should be defined for a list component ({@code Table}, {@code DataGrid}, etc.) in a screen XML descriptor.
  */
-@StudioAction(category = "List Actions", description = "Reloads a list of entities from the database")
+@StudioAction(
+        target = "io.jmix.ui.component.ListComponent",
+        description = "Reloads a list of entities from the database",
+        availableInScreenWizard = true)
 @ActionType(RefreshAction.ID)
 public class RefreshAction extends ListAction implements Action.ExecutableAction {
 

--- a/ui/src/main/java/io/jmix/ui/action/list/RelatedAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/list/RelatedAction.java
@@ -37,7 +37,9 @@ import javax.annotation.Nullable;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-@StudioAction(category = "List Actions", description = "Opens a browser screen with list of related entities")
+@StudioAction(
+        target = "io.jmix.ui.component.ListComponent",
+        description = "Opens a browser screen with list of related entities")
 @ActionType(RelatedAction.ID)
 public class RelatedAction extends SecuredListAction
         implements Action.AdjustWhenScreenReadOnly, Action.ScreenOpeningAction, Action.ExecutableAction {

--- a/ui/src/main/java/io/jmix/ui/action/list/RemoveAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/list/RemoveAction.java
@@ -47,7 +47,10 @@ import java.util.function.Consumer;
  * The action instance can be parameterized using the nested {@code properties} XML element or programmatically in the
  * screen controller.
  */
-@StudioAction(category = "List Actions", description = "Removes an entity instance from the list and from the database")
+@StudioAction(
+        target = "io.jmix.ui.component.ListComponent",
+        description = "Removes an entity instance from the list and from the database",
+        availableInScreenWizard = true)
 @ActionType(RemoveAction.ID)
 public class RemoveAction<E> extends SecuredListAction implements Action.AdjustWhenScreenReadOnly,
         Action.ExecutableAction {

--- a/ui/src/main/java/io/jmix/ui/action/list/ViewAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/list/ViewAction.java
@@ -50,7 +50,9 @@ import static io.jmix.ui.screen.FrameOwner.WINDOW_COMMIT_AND_CLOSE_ACTION;
  * The action instance can be parameterized using the nested {@code properties} XML element or programmatically in the
  * screen controller.
  */
-@StudioAction(category = "List Actions", description = "Opens an editor screen for an entity instance in read-only mode")
+@StudioAction(
+        target = "io.jmix.ui.component.ListComponent",
+        description = "Opens an editor screen for an entity instance in read-only mode")
 @ActionType(ViewAction.ID)
 public class ViewAction<E> extends SecuredListAction implements Action.ScreenOpeningAction, Action.ExecutableAction {
 

--- a/ui/src/main/java/io/jmix/ui/action/tagpicker/TagLookupAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/tagpicker/TagLookupAction.java
@@ -29,7 +29,6 @@ import io.jmix.ui.meta.StudioAction;
 import io.jmix.ui.meta.StudioPropertiesItem;
 import io.jmix.ui.screen.MultiSelectLookupScreen;
 import io.jmix.ui.screen.Screen;
-import io.jmix.ui.sys.ActionScreenInitializer;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -41,7 +40,7 @@ import javax.annotation.Nullable;
  * @param <E> type of entity
  */
 @StudioAction(
-        category = "TagPicker Actions",
+        target = "io.jmix.ui.component.TagPicker",
         description = "Sets an entity to the tag picker using the entity lookup screen")
 @ActionType(TagLookupAction.ID)
 public class TagLookupAction<E> extends AbstractLookupAction<E>

--- a/ui/src/main/java/io/jmix/ui/action/valuepicker/ValueClearAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/valuepicker/ValueClearAction.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
  * <p>
  * Should be defined for {@link ValuePicker} or its subclass in a screen XML descriptor.
  */
-@StudioAction(category = "ValuePicker Actions", description = "Clears the value picker value")
+@StudioAction(target = "io.jmix.ui.component.ValuePicker", description = "Clears the value picker value")
 @ActionType(ValueClearAction.ID)
 public class ValueClearAction extends BaseAction implements ValuePicker.ValuePickerAction, InitializingBean,
         Action.ExecutableAction {

--- a/ui/src/main/java/io/jmix/ui/action/valuespicker/ValuesSelectAction.java
+++ b/ui/src/main/java/io/jmix/ui/action/valuespicker/ValuesSelectAction.java
@@ -59,7 +59,7 @@ import static io.jmix.ui.screen.FrameOwner.WINDOW_COMMIT_AND_CLOSE_ACTION;
  * Should be defined for {@link ValuesPicker} or its subclass in a screen XML descriptor.
  */
 @StudioAction(
-        category = "ValuesPicker Actions",
+        target = "io.jmix.ui.component.ValuesPicker",
         description = "Sets a value to the values picker using the selection screen")
 @ActionType(ValuesSelectAction.ID)
 public class ValuesSelectAction<V> extends BaseAction implements ValuePickerAction, InitializingBean,

--- a/ui/src/main/java/io/jmix/ui/meta/StudioAction.java
+++ b/ui/src/main/java/io/jmix/ui/meta/StudioAction.java
@@ -39,12 +39,19 @@ public @interface StudioAction {
     String description() default "";
 
     /**
-     * Category of the action in Screen Designer Palette.
+     * Fully-qualified class names of the components to which the action can be applied.
+     * Some base interface is expected in most cases.
+     * E.g. "io.jmix.ui.component.ListComponent"
      */
-    String category() default "";
+    String[] target() default {};
 
     /**
      * Component Palette icon, SVG or PNG.
      */
     String icon() default "";
+
+    /**
+     * Indicates that action should be available in screen wizard
+     */
+    boolean availableInScreenWizard() default false;
 }


### PR DESCRIPTION
Removed `category` attribute as we don't have actions in the Component Palette. It was replaced with `target`.
Added `availableInScreenWizard` boolean attribute.
Table actions with `availableInScreenWizard = true` are shown in entity browser screen wizard and available for browser table initialization.

related Studio ticket JST-517